### PR TITLE
Add route planner translated from Kotlin

### DIFF
--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -1,0 +1,35 @@
+package graph
+
+// System представляет солнечную систему EVE.
+type System struct {
+	ID       int
+	Name     string
+	Security float64
+	RegionID int
+}
+
+// Graph хранит минимальные данные о карте.
+type Graph struct {
+	Systems     []System
+	Connections [][2]int // каждая пара содержит ID соединённых систем
+	Regions     map[int]string
+}
+
+// DefaultGraph возвращает небольшой пример графа.
+func DefaultGraph() Graph {
+	return Graph{
+		Systems: []System{
+			{ID: 1, Name: "Alpha", Security: 0.5, RegionID: 1},
+			{ID: 2, Name: "Beta", Security: 0.6, RegionID: 1},
+			{ID: 3, Name: "Gamma", Security: 0.7, RegionID: 1},
+		},
+		Connections: [][2]int{
+			{1, 2},
+			{2, 3},
+			{1, 3},
+		},
+		Regions: map[int]string{
+			1: "Demo Region",
+		},
+	}
+}

--- a/internal/graph/helper.go
+++ b/internal/graph/helper.go
@@ -1,0 +1,52 @@
+package graph
+
+import "strings"
+
+// Helper предоставляет вспомогательные функции для работы с графом.
+type Helper struct {
+	graph Graph
+}
+
+// NewHelper создаёт новый экземпляр Helper.
+func NewHelper(g Graph) *Helper {
+	return &Helper{graph: g}
+}
+
+// Graph возвращает исходный граф.
+func (h *Helper) Graph() Graph { return h.graph }
+
+// FindSystemByName ищет систему по имени (без учёта регистра).
+func (h *Helper) FindSystemByName(name string) *System {
+	for _, s := range h.graph.Systems {
+		if strings.EqualFold(s.Name, name) {
+			sCopy := s
+			return &sCopy
+		}
+	}
+	return nil
+}
+
+// FindSystem ищет систему по ID.
+func (h *Helper) FindSystem(id int) *System {
+	for _, s := range h.graph.Systems {
+		if s.ID == id {
+			sCopy := s
+			return &sCopy
+		}
+	}
+	return nil
+}
+
+// GetEndSystem возвращает конечную систему из названия Ansiblex.
+// Формат названия: "Start » End - ...".
+func (h *Helper) GetEndSystem(ansiblexName string) *System {
+	parts := strings.Split(ansiblexName, " » ")
+	if len(parts) < 2 {
+		return nil
+	}
+	end := parts[1]
+	if idx := strings.Index(end, " - "); idx != -1 {
+		end = end[:idx]
+	}
+	return h.FindSystemByName(end)
+}

--- a/internal/route/node.go
+++ b/internal/route/node.go
@@ -1,0 +1,53 @@
+package route
+
+// Node представляет узел графа.
+type Node struct {
+	Value       GraphSystem
+	connections []Connection
+}
+
+// Connection соединение между узлами.
+type Connection struct {
+	Node *Node
+	Type WaypointType
+}
+
+// Connect соединяет узлы в обе стороны, если они ещё не соединены.
+func (n *Node) Connect(other *Node, t WaypointType) {
+	if n == other {
+		return
+	}
+	if !n.isConnected(other, t) {
+		n.connections = append(n.connections, Connection{Node: other, Type: t})
+	}
+	if !other.isConnected(n, t) {
+		other.connections = append(other.connections, Connection{Node: n, Type: t})
+	}
+}
+
+func (n *Node) isConnected(other *Node, t WaypointType) bool {
+	for _, c := range n.connections {
+		if c.Node == other && c.Type == t {
+			return true
+		}
+	}
+	return false
+}
+
+// Connections возвращает все соединения узла.
+func (n *Node) Connections() []Connection { return n.connections }
+
+type path struct {
+	waypoints []Waypoint
+}
+
+// numberOfAnsiblexes возвращает количество переходов через Ansiblex.
+func (p path) numberOfAnsiblexes() int {
+	count := 0
+	for _, w := range p.waypoints {
+		if w.ConnectionType != nil && *w.ConnectionType == TypeAnsiblex {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/route/route.go
+++ b/internal/route/route.go
@@ -1,0 +1,216 @@
+package route
+
+import (
+	"github.com/tkhamez/eve-route-go/internal/graph"
+	"log"
+	"sort"
+)
+
+// Route ищет пути между системами на основании графа.
+type Route struct {
+	graphHelper        *graph.Helper
+	avoidedSystems     map[int]bool
+	removedConnections []ConnectedSystems
+
+	allSystems              map[int]GraphSystem
+	allNodes                map[int]*Node
+	allAnsiblexes           map[int]MongoAnsiblex
+	allTemporaryConnections map[int]MongoTemporaryConnection
+}
+
+// NewRoute создаёт новый экземпляр маршрутизатора.
+func NewRoute(ansiblexes []MongoAnsiblex, tempConnections []MongoTemporaryConnection, avoided map[int]bool, removed []ConnectedSystems) *Route {
+	g := graph.DefaultGraph()
+	helper := graph.NewHelper(g)
+	r := &Route{
+		graphHelper:             helper,
+		avoidedSystems:          avoided,
+		removedConnections:      removed,
+		allSystems:              map[int]GraphSystem{},
+		allNodes:                map[int]*Node{},
+		allAnsiblexes:           map[int]MongoAnsiblex{},
+		allTemporaryConnections: map[int]MongoTemporaryConnection{},
+	}
+	r.buildNodes()
+	r.addGates(ansiblexes)
+	r.addTempConnections(tempConnections)
+	return r
+}
+
+// Find ищет пути от from до to. Возвращает список маршрутов с набором точек.
+func (r *Route) Find(from, to string) [][]Waypoint {
+	log.Printf("route planner: %s -> %s", from, to)
+	startSystem := r.graphHelper.FindSystemByName(from)
+	endSystem := r.graphHelper.FindSystemByName(to)
+	if startSystem == nil || endSystem == nil {
+		return [][]Waypoint{}
+	}
+	startNode := r.allNodes[startSystem.ID]
+	if startNode == nil {
+		return [][]Waypoint{}
+	}
+	connections := r.search(*endSystem, startNode)
+	var paths []path
+	for _, c := range connections {
+		wp := r.buildWaypoints(c)
+		paths = append(paths, path{waypoints: wp})
+	}
+	sort.Slice(paths, func(i, j int) bool {
+		return paths[i].numberOfAnsiblexes() < paths[j].numberOfAnsiblexes()
+	})
+	var result [][]Waypoint
+	for _, p := range paths {
+		result = append(result, p.waypoints)
+	}
+	return result
+}
+
+// buildNodes создаёт узлы и соединяет их в соответствии с графом.
+func (r *Route) buildNodes() {
+	g := r.graphHelper.Graph()
+	for _, s := range g.Systems {
+		r.allSystems[s.ID] = s
+	}
+	for _, c := range g.Connections {
+		src := r.getNode(c[0])
+		dst := r.getNode(c[1])
+		if src != nil && dst != nil && !r.isRemoved(src.Value.Name, dst.Value.Name) {
+			src.Connect(dst, TypeStargate)
+		}
+	}
+}
+
+func (r *Route) addGates(ansiblexes []MongoAnsiblex) {
+	for _, gate := range ansiblexes {
+		r.allAnsiblexes[gate.SolarSystemID] = gate
+		end := r.graphHelper.GetEndSystem(gate.Name)
+		if end == nil {
+			continue
+		}
+		startNode := r.getNode(gate.SolarSystemID)
+		endNode := r.getNode(end.ID)
+		if startNode != nil && endNode != nil && !r.isRemoved(startNode.Value.Name, endNode.Value.Name) {
+			startNode.Connect(endNode, TypeAnsiblex)
+		}
+	}
+}
+
+func (r *Route) addTempConnections(conns []MongoTemporaryConnection) {
+	for _, c := range conns {
+		r.allTemporaryConnections[c.System1ID] = c
+		r.allTemporaryConnections[c.System2ID] = c
+		n1 := r.getNode(c.System1ID)
+		n2 := r.getNode(c.System2ID)
+		if n1 != nil && n2 != nil && !r.isRemoved(n1.Value.Name, n2.Value.Name) {
+			n1.Connect(n2, TypeTemporary)
+		}
+	}
+}
+
+func (r *Route) isRemoved(startName, endName string) bool {
+	for _, rc := range r.removedConnections {
+		if (rc.System1 == startName && rc.System2 == endName) || (rc.System1 == endName && rc.System2 == startName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Route) getNode(systemID int) *Node {
+	if r.avoidedSystems != nil && r.avoidedSystems[systemID] {
+		return nil
+	}
+	if n, ok := r.allNodes[systemID]; ok {
+		return n
+	}
+	if s, ok := r.allSystems[systemID]; ok {
+		node := &Node{Value: s}
+		r.allNodes[systemID] = node
+		return node
+	}
+	return nil
+}
+
+func (r *Route) search(goal GraphSystem, start *Node) [][]Connection {
+	type connPath []Connection
+	var found []connPath
+	queue := []connPath{{{Node: start}}}
+	visited := map[*Node]bool{}
+	lastLen := 0
+	for len(queue) > 0 {
+		p := queue[0]
+		queue = queue[1:]
+		current := p[len(p)-1]
+		if lastLen > 0 && len(p) > lastLen {
+			continue
+		}
+		if current.Node.Value.ID == goal.ID {
+			if lastLen == 0 || len(p) < lastLen {
+				found = []connPath{p}
+				lastLen = len(p)
+			} else if len(p) == lastLen {
+				found = append(found, p)
+			}
+			continue
+		}
+		if visited[current.Node] {
+			continue
+		}
+		visited[current.Node] = true
+		for _, c := range current.Node.Connections() {
+			newPath := append(connPath{}, p...)
+			newPath = append(newPath, c)
+			queue = append(queue, newPath)
+		}
+	}
+	var result [][]Connection
+	for _, p := range found {
+		result = append(result, []Connection(p))
+	}
+	return result
+}
+
+func (r *Route) buildWaypoints(path []Connection) []Waypoint {
+	var waypoints []Waypoint
+	for i := len(path) - 1; i >= 0; i-- {
+		conn := path[i]
+		system := conn.Node.Value
+		var prevSystem *GraphSystem
+		if i < len(path)-1 {
+			prevSystem = &path[i+1].Node.Value
+		}
+		var ansiblexID *int64
+		var ansiblexName *string
+		if i < len(path)-1 && path[i+1].Type == TypeAnsiblex {
+			if gate, ok := r.allAnsiblexes[system.ID]; ok {
+				ansiblexID = &gate.ID
+				ansiblexName = &gate.Name
+			}
+		}
+		var prevName *string
+		if prevSystem != nil {
+			name := prevSystem.Name
+			prevName = &name
+		}
+		w := Waypoint{
+			SystemID:       system.ID,
+			SystemName:     system.Name,
+			TargetSystem:   prevName,
+			Wormhole:       system.ID >= 31000000 && system.ID <= 32000000,
+			SystemSecurity: system.Security,
+			RegionName:     r.graphHelper.Graph().Regions[system.RegionID],
+		}
+		if i < len(path)-1 {
+			t := path[i+1].Type
+			w.ConnectionType = &t
+			w.AnsiblexID = ansiblexID
+			w.AnsiblexName = ansiblexName
+		}
+		waypoints = append(waypoints, w)
+	}
+	// reverse
+	for i, j := 0, len(waypoints)-1; i < j; i, j = i+1, j-1 {
+		waypoints[i], waypoints[j] = waypoints[j], waypoints[i]
+	}
+	return waypoints
+}

--- a/internal/route/route_test.go
+++ b/internal/route/route_test.go
@@ -1,0 +1,22 @@
+package route
+
+import "testing"
+
+func TestRouteFindAnsiblex(t *testing.T) {
+	ansiblexes := []MongoAnsiblex{
+		{ID: 1, Name: "Alpha » Gamma - Gate1", SolarSystemID: 1},
+		{ID: 2, Name: "Gamma » Alpha - Gate2", SolarSystemID: 3},
+	}
+	r := NewRoute(ansiblexes, nil, nil, nil)
+	paths := r.Find("Alpha", "Gamma")
+	t.Logf("paths: %d", len(paths))
+	if len(paths) != 2 {
+		t.Fatalf("ожидались два маршрута, получено %d", len(paths))
+	}
+	if paths[0][0].ConnectionType == nil || *paths[0][0].ConnectionType != TypeStargate {
+		t.Fatalf("первый маршрут должен идти через Stargate")
+	}
+	if paths[1][0].ConnectionType == nil || *paths[1][0].ConnectionType != TypeAnsiblex {
+		t.Fatalf("второй маршрут должен использовать Ansiblex")
+	}
+}

--- a/internal/route/types.go
+++ b/internal/route/types.go
@@ -1,0 +1,48 @@
+package route
+
+import "github.com/tkhamez/eve-route-go/internal/graph"
+
+// MongoAnsiblex описывает Ansiblex-ворота.
+type MongoAnsiblex struct {
+	ID            int64
+	Name          string
+	SolarSystemID int
+	RegionID      *int
+}
+
+// MongoTemporaryConnection описывает временное соединение между системами.
+type MongoTemporaryConnection struct {
+	System1ID int
+	System2ID int
+}
+
+// ConnectedSystems — пара систем, связь между которыми удалена пользователем.
+type ConnectedSystems struct {
+	System1 string
+	System2 string
+}
+
+// Waypoint описывает один шаг маршрута.
+type Waypoint struct {
+	SystemID       int
+	SystemName     string
+	TargetSystem   *string
+	Wormhole       bool
+	SystemSecurity float64
+	ConnectionType *WaypointType
+	AnsiblexID     *int64
+	AnsiblexName   *string
+	RegionName     string
+}
+
+// WaypointType тип соединения.
+type WaypointType string
+
+const (
+	TypeStargate  WaypointType = "Stargate"
+	TypeAnsiblex  WaypointType = "Ansiblex"
+	TypeTemporary WaypointType = "Temporary"
+)
+
+// Helper alias для системного типа из пакета graph.
+type GraphSystem = graph.System


### PR DESCRIPTION
## Summary
- add graph helper and data types
- implement route planner with BFS and Ansiblex support
- cover route planner with tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689a7021e40c8325af4ddbc5491d61e9