### PR TITLE
Add environment configuration package

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"log"
+	"os"
+)
+
+// Config содержит настройки приложения.
+type Config struct {
+	DatabaseURL string
+	Port        string
+}
+
+// FromEnv читает переменные окружения и возвращает Config.
+// Если переменная PORT не задана, используется значение по умолчанию 8080.
+func FromEnv() Config {
+	cfg := Config{
+		DatabaseURL: os.Getenv("DATABASE_URL"),
+		Port:        os.Getenv("PORT"),
+	}
+	if cfg.Port == "" {
+		cfg.Port = "8080"
+	}
+	log.Printf("config loaded: port=%s", cfg.Port)
+	return cfg
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,24 @@
+package config
+
+import "testing"
+
+func TestFromEnv(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://user:pass@localhost/db")
+	t.Setenv("PORT", "9090")
+	cfg := FromEnv()
+	if cfg.DatabaseURL != "postgres://user:pass@localhost/db" {
+		t.Fatalf("unexpected DatabaseURL: %s", cfg.DatabaseURL)
+	}
+	if cfg.Port != "9090" {
+		t.Fatalf("unexpected Port: %s", cfg.Port)
+	}
+}
+
+func TestFromEnvDefaultPort(t *testing.T) {
+	t.Setenv("DATABASE_URL", "")
+	t.Setenv("PORT", "")
+	cfg := FromEnv()
+	if cfg.Port != "8080" {
+		t.Fatalf("expected default port 8080, got %s", cfg.Port)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -9,12 +9,18 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/tkhamez/eve-route-go/internal/capital"
+	"github.com/tkhamez/eve-route-go/internal/config"
 )
 
 //go:embed frontend/dist
 var frontendFS embed.FS
 
 func main() {
+	cfg := config.FromEnv()
+	if cfg.DatabaseURL == "" {
+		log.Println("DATABASE_URL is not set")
+	}
+
 	r := mux.NewRouter()
 
 	// API endpoint for capital jump planner
@@ -37,6 +43,7 @@ func main() {
 	// serve static frontend
 	r.PathPrefix("/").Handler(http.FileServer(http.FS(frontendFS)))
 
-	log.Println("server started on :8080")
-	log.Fatal(http.ListenAndServe(":8080", r))
+	addr := ":" + cfg.Port
+	log.Printf("server started on %s", addr)
+	log.Fatal(http.ListenAndServe(addr, r))
 }


### PR DESCRIPTION
## Summary
- add config package for reading DATABASE_URL and PORT from environment
- use configuration in main.go instead of hardcoded port
- test configuration parsing and defaults

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689a893483ac83259a575e5006242864