### PR TITLE
Add capital jump planner page

### DIFF
--- a/frontend/src/pages/CapitalJumpPlanner.test.tsx
+++ b/frontend/src/pages/CapitalJumpPlanner.test.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { ThemeProvider } from "@material-ui/core/styles";
+import theme from "../theme";
+import CapitalJumpPlanner from "./CapitalJumpPlanner";
+
+test("CapitalJumpPlanner snapshot", () => {
+  const { container } = render(
+    <ThemeProvider theme={theme}>
+      <CapitalJumpPlanner />
+    </ThemeProvider>,
+  );
+  expect(container).toMatchSnapshot();
+});

--- a/frontend/src/pages/CapitalJumpPlanner.tsx
+++ b/frontend/src/pages/CapitalJumpPlanner.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from "react";
+import { Box, Button, Grid, Typography } from "@material-ui/core";
+import axios from "axios";
+import SystemInput from "../components/SystemInput";
+
+interface ApiResponse {
+  route: Array<{ id: number; name: string }>;
+}
+
+/**
+ * Страница планировщика прыжков капитальных кораблей.
+ * Позволяет выбрать начальную и конечную системы
+ * и рассчитать маршрут через API.
+ */
+export default function CapitalJumpPlanner() {
+  const [start, setStart] = useState("");
+  const [end, setEnd] = useState("");
+  const [names, setNames] = useState<string[]>([]);
+  const [message, setMessage] = useState("");
+
+  const findRoute = () => {
+    setMessage("");
+    if (!start || !end) {
+      return;
+    }
+    console.log("Requesting capital route", start, end);
+    axios
+      .get<ApiResponse>(`/api/capital?start=${start}&end=${end}`)
+      .then((r) => {
+        setNames(r.data.route.map((s) => s.name));
+      })
+      .catch((err) => {
+        console.error("Failed to fetch capital route", err);
+        setMessage("No route found");
+      });
+  };
+
+  return (
+    <Grid container spacing={2} className="card">
+      <Grid item xs={12}>
+        <Typography variant="h6" align="center">
+          Capital Jump Planner
+        </Typography>
+      </Grid>
+
+      <Grid item sm={5} xs={12}>
+        <Box display="flex" justifyContent="center">
+          <SystemInput
+            fieldId="start-system"
+            fieldName="Start"
+            onChange={setStart}
+            fieldValue={start}
+            findRoute={findRoute}
+          />
+        </Box>
+      </Grid>
+      <Grid item sm={2} xs={12}></Grid>
+      <Grid item sm={5} xs={12}>
+        <Box display="flex" justifyContent="center">
+          <SystemInput
+            fieldId="end-system"
+            fieldName="End"
+            onChange={setEnd}
+            fieldValue={end}
+            findRoute={findRoute}
+          />
+        </Box>
+      </Grid>
+
+      <Grid item xs={12}>
+        <Box display="flex" justifyContent="center">
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={findRoute}
+            disabled={!(start && end)}
+          >
+            Find Route
+          </Button>
+        </Box>
+      </Grid>
+
+      <Grid item xs={12}>
+        {message && <Typography>{message}</Typography>}
+        {!message && names.length > 0 && (
+          <ol>
+            {names.map((n, i) => (
+              <li key={i}>{n}</li>
+            ))}
+          </ol>
+        )}
+      </Grid>
+    </Grid>
+  );
+}

--- a/frontend/src/pages/__snapshots__/CapitalJumpPlanner.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/CapitalJumpPlanner.test.tsx.snap
@@ -1,0 +1,279 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CapitalJumpPlanner snapshot 1`] = `
+<div>
+  <div
+    class="MuiGrid-root card MuiGrid-container MuiGrid-spacing-xs-2"
+  >
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+    >
+      <h6
+        class="MuiTypography-root MuiTypography-h6 MuiTypography-alignCenter"
+      >
+        Capital Jump Planner
+      </h6>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-5"
+    >
+      <div
+        class="MuiBox-root MuiBox-root-1"
+      >
+        <div
+          class="makeStyles-wrap-2"
+          id="start-system-wrap"
+        >
+          <div
+            class="MuiFormControl-root MuiTextField-root makeStyles-textField-3"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
+              data-shrink="true"
+              for="start-system"
+              id="start-system-label"
+            >
+              Start
+            </label>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
+            >
+              <div
+                class="MuiInputAdornment-root MuiInputAdornment-positionStart"
+              >
+                <button
+                  class="MuiButtonBase-root MuiIconButton-root makeStyles-location-4 MuiIconButton-sizeSmall"
+                  tabindex="0"
+                  title="systemInput.current-location"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zM7 9c0-2.76 2.24-5 5-5s5 2.24 5 5c0 2.88-2.88 7.19-5 9.88C9.92 16.21 7 11.85 7 9z"
+                      />
+                      <circle
+                        cx="12"
+                        cy="9"
+                        r="2.5"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+              <input
+                aria-invalid="false"
+                autocomplete="off"
+                class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+                id="start-system"
+                type="text"
+                value=""
+              />
+              <div
+                class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+              >
+                <div
+                  class="MuiCircularProgress-root makeStyles-loadingHidden-6 MuiCircularProgress-indeterminate"
+                  role="progressbar"
+                  style="width: 15px; height: 15px;"
+                >
+                  <svg
+                    class="MuiCircularProgress-svg"
+                    viewBox="22 22 44 44"
+                  >
+                    <circle
+                      class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate"
+                      cx="44"
+                      cy="44"
+                      fill="none"
+                      r="20.2"
+                      stroke-width="3.6"
+                    />
+                  </svg>
+                </div>
+                 
+                <button
+                  class="MuiButtonBase-root MuiIconButton-root makeStyles-clearIndicator-5 MuiIconButton-sizeSmall"
+                  style="visibility: hidden;"
+                  tabindex="0"
+                  title="systemInput.clear"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+              <fieldset
+                aria-hidden="true"
+                class="PrivateNotchedOutline-root-8 MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="PrivateNotchedOutline-legendLabelled-10 PrivateNotchedOutline-legendNotched-11"
+                >
+                  <span>
+                    Start
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-2"
+    />
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-5"
+    >
+      <div
+        class="MuiBox-root MuiBox-root-12"
+      >
+        <div
+          class="makeStyles-wrap-2"
+          id="end-system-wrap"
+        >
+          <div
+            class="MuiFormControl-root MuiTextField-root makeStyles-textField-3"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined"
+              data-shrink="true"
+              for="end-system"
+              id="end-system-label"
+            >
+              End
+            </label>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
+            >
+              <div
+                class="MuiInputAdornment-root MuiInputAdornment-positionStart"
+              />
+              <input
+                aria-invalid="false"
+                autocomplete="off"
+                class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+                id="end-system"
+                type="text"
+                value=""
+              />
+              <div
+                class="MuiInputAdornment-root MuiInputAdornment-positionEnd"
+              >
+                <div
+                  class="MuiCircularProgress-root makeStyles-loadingHidden-6 MuiCircularProgress-indeterminate"
+                  role="progressbar"
+                  style="width: 15px; height: 15px;"
+                >
+                  <svg
+                    class="MuiCircularProgress-svg"
+                    viewBox="22 22 44 44"
+                  >
+                    <circle
+                      class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate"
+                      cx="44"
+                      cy="44"
+                      fill="none"
+                      r="20.2"
+                      stroke-width="3.6"
+                    />
+                  </svg>
+                </div>
+                 
+                <button
+                  class="MuiButtonBase-root MuiIconButton-root makeStyles-clearIndicator-5 MuiIconButton-sizeSmall"
+                  style="visibility: hidden;"
+                  tabindex="0"
+                  title="systemInput.clear"
+                  type="button"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+              <fieldset
+                aria-hidden="true"
+                class="PrivateNotchedOutline-root-8 MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="PrivateNotchedOutline-legendLabelled-10 PrivateNotchedOutline-legendNotched-11"
+                >
+                  <span>
+                    End
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+    >
+      <div
+        class="MuiBox-root MuiBox-root-13"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary Mui-disabled Mui-disabled"
+          disabled=""
+          tabindex="-1"
+          type="button"
+        >
+          <span
+            class="MuiButton-label"
+          >
+            Find Route
+          </span>
+        </button>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+    >
+      
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
## Summary
- add capital jump planner page using `/api/capital`
- cover capital jump planner with snapshot test

## Testing
- `CI=true yarn test`

------
https://chatgpt.com/codex/tasks/task_e_689a892c94f08325995768ff53bfa153