### PR TITLE
Add Ansiblex API with auth and tests

### DIFF
--- a/internal/api/ansiblex.go
+++ b/internal/api/ansiblex.go
@@ -1,0 +1,195 @@
+package api
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+// Ansiblex represents a permanent jump bridge.
+type Ansiblex struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// TempConnection describes a temporary connection between systems.
+type TempConnection struct {
+	ID      int       `json:"id"`
+	From    string    `json:"from"`
+	To      string    `json:"to"`
+	Expires time.Time `json:"expires"`
+}
+
+// Store keeps Ansiblex and temporary connections in memory.
+type Store struct {
+	mu       sync.Mutex
+	nextID   int
+	ansiblex map[int]Ansiblex
+	temp     map[int]TempConnection
+}
+
+// NewStore creates a new in-memory store.
+func NewStore() *Store {
+	return &Store{ansiblex: make(map[int]Ansiblex), temp: make(map[int]TempConnection), nextID: 1}
+}
+
+// RegisterAnsiblexRoutes registers API routes for Ansiblex and temporary connections.
+func RegisterAnsiblexRoutes(r *mux.Router, token string) *Store {
+	s := NewStore()
+	api := r.PathPrefix("/api").Subrouter()
+
+	api.HandleFunc("/ansiblex", s.listAnsiblex).Methods("GET")
+	api.Handle("/ansiblex", s.auth(token, http.HandlerFunc(s.createAnsiblex))).Methods("POST")
+	api.Handle("/ansiblex/{id}", s.auth(token, http.HandlerFunc(s.updateAnsiblex))).Methods("PUT")
+	api.Handle("/ansiblex/{id}", s.auth(token, http.HandlerFunc(s.deleteAnsiblex))).Methods("DELETE")
+
+	api.HandleFunc("/temp", s.listTemp).Methods("GET")
+	api.Handle("/temp", s.auth(token, http.HandlerFunc(s.createTemp))).Methods("POST")
+	api.Handle("/temp/{id}", s.auth(token, http.HandlerFunc(s.updateTemp))).Methods("PUT")
+	api.Handle("/temp/{id}", s.auth(token, http.HandlerFunc(s.deleteTemp))).Methods("DELETE")
+
+	return s
+}
+
+func (s *Store) auth(token string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+token {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s *Store) listAnsiblex(w http.ResponseWriter, _ *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var list []Ansiblex
+	for _, a := range s.ansiblex {
+		list = append(list, a)
+	}
+	_ = json.NewEncoder(w).Encode(list)
+}
+
+func (s *Store) createAnsiblex(w http.ResponseWriter, r *http.Request) {
+	var a Ansiblex
+	if err := json.NewDecoder(r.Body).Decode(&a); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.mu.Lock()
+	a.ID = s.nextID
+	s.nextID++
+	s.ansiblex[a.ID] = a
+	s.mu.Unlock()
+	log.Printf("ansiblex created: %d", a.ID)
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(a)
+}
+
+func (s *Store) updateAnsiblex(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.Atoi(mux.Vars(r)["id"])
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	var a Ansiblex
+	if err := json.NewDecoder(r.Body).Decode(&a); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.mu.Lock()
+	if _, ok := s.ansiblex[id]; !ok {
+		s.mu.Unlock()
+		http.NotFound(w, r)
+		return
+	}
+	a.ID = id
+	s.ansiblex[id] = a
+	s.mu.Unlock()
+	log.Printf("ansiblex updated: %d", id)
+	_ = json.NewEncoder(w).Encode(a)
+}
+
+func (s *Store) deleteAnsiblex(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.Atoi(mux.Vars(r)["id"])
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.mu.Lock()
+	delete(s.ansiblex, id)
+	s.mu.Unlock()
+	log.Printf("ansiblex deleted: %d", id)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Store) listTemp(w http.ResponseWriter, _ *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var list []TempConnection
+	for _, t := range s.temp {
+		list = append(list, t)
+	}
+	_ = json.NewEncoder(w).Encode(list)
+}
+
+func (s *Store) createTemp(w http.ResponseWriter, r *http.Request) {
+	var t TempConnection
+	if err := json.NewDecoder(r.Body).Decode(&t); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.mu.Lock()
+	t.ID = s.nextID
+	s.nextID++
+	s.temp[t.ID] = t
+	s.mu.Unlock()
+	log.Printf("temp connection created: %d", t.ID)
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(t)
+}
+
+func (s *Store) updateTemp(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.Atoi(mux.Vars(r)["id"])
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	var t TempConnection
+	if err := json.NewDecoder(r.Body).Decode(&t); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.mu.Lock()
+	if _, ok := s.temp[id]; !ok {
+		s.mu.Unlock()
+		http.NotFound(w, r)
+		return
+	}
+	t.ID = id
+	s.temp[id] = t
+	s.mu.Unlock()
+	log.Printf("temp connection updated: %d", id)
+	_ = json.NewEncoder(w).Encode(t)
+}
+
+func (s *Store) deleteTemp(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.Atoi(mux.Vars(r)["id"])
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.mu.Lock()
+	delete(s.temp, id)
+	s.mu.Unlock()
+	log.Printf("temp connection deleted: %d", id)
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/api/ansiblex_test.go
+++ b/internal/api/ansiblex_test.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+func TestAnsiblexAuth(t *testing.T) {
+	r := mux.NewRouter()
+	RegisterAnsiblexRoutes(r, "token")
+
+	body := bytes.NewBufferString(`{"name":"A","from":"X","to":"Y"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/ansiblex", body)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+
+	body = bytes.NewBufferString(`{"name":"A","from":"X","to":"Y"}`)
+	req = httptest.NewRequest(http.MethodPost, "/api/ansiblex", body)
+	req.Header.Set("Authorization", "Bearer token")
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", w.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/ansiblex", nil)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var list []Ansiblex
+	if err := json.NewDecoder(w.Body).Decode(&list); err != nil || len(list) != 1 {
+		t.Fatalf("expected one element, got %v %v", len(list), err)
+	}
+}
+
+func TestTempAuth(t *testing.T) {
+	r := mux.NewRouter()
+	RegisterAnsiblexRoutes(r, "token")
+
+	body := bytes.NewBufferString(`{"from":"X","to":"Y"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/temp", body)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/tkhamez/eve-route-go/internal/api"
 	"github.com/tkhamez/eve-route-go/internal/capital"
 )
 
@@ -16,6 +17,8 @@ var frontendFS embed.FS
 
 func main() {
 	r := mux.NewRouter()
+
+	api.RegisterAnsiblexRoutes(r, "secret")
 
 	// API endpoint for capital jump planner
 	p := capital.NewPlanner(capital.DefaultSystems(), 5)


### PR DESCRIPTION
## Summary
- add in-memory Ansiblex and temporary connection storage with CRUD API
- protect modifying endpoints with a bearer token
- cover API authorization with tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689a89465f088325a45eb66d9643f8b4