### PR TITLE
Add tests for graph helper functions

### DIFF
--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -1,0 +1,27 @@
+package graph
+
+import (
+	"log"
+	"reflect"
+	"testing"
+)
+
+// TestDefaultGraph проверяет создание стандартного графа.
+func TestDefaultGraph(t *testing.T) {
+	g := DefaultGraph()
+	log.Printf("получен граф: %+v", g)
+
+	if len(g.Systems) != 3 {
+		t.Fatalf("ожидалось 3 системы, получено %d", len(g.Systems))
+	}
+	if g.Systems[0].Name != "Alpha" {
+		t.Errorf("ожидалась первая система Alpha, получено %s", g.Systems[0].Name)
+	}
+	expectedRegions := map[int]string{1: "Demo Region"}
+	if !reflect.DeepEqual(g.Regions, expectedRegions) {
+		t.Errorf("неверные регионы: %+v", g.Regions)
+	}
+	if len(g.Connections) != 3 {
+		t.Errorf("ожидалось 3 соединения, получено %d", len(g.Connections))
+	}
+}

--- a/internal/graph/helper_test.go
+++ b/internal/graph/helper_test.go
@@ -1,0 +1,62 @@
+package graph
+
+import (
+	"log"
+	"reflect"
+	"testing"
+)
+
+// TestNewHelperAndGraph проверяет создание Helper и возврат графа.
+func TestNewHelperAndGraph(t *testing.T) {
+	g := DefaultGraph()
+	h := NewHelper(g)
+	log.Printf("создан helper: %+v", h)
+
+	if !reflect.DeepEqual(h.Graph(), g) {
+		t.Errorf("ожидался граф %+v, получено %+v", g, h.Graph())
+	}
+}
+
+// TestFindSystemByName проверяет поиск системы по имени.
+func TestFindSystemByName(t *testing.T) {
+	h := NewHelper(DefaultGraph())
+
+	s := h.FindSystemByName("beta")
+	log.Printf("найдена система: %+v", s)
+	if s == nil || s.Name != "Beta" {
+		t.Fatalf("ожидалась система Beta, получено %#v", s)
+	}
+	if res := h.FindSystemByName("unknown"); res != nil {
+		t.Errorf("ожидалось nil, получено %+v", res)
+	}
+}
+
+// TestFindSystem проверяет поиск системы по ID.
+func TestFindSystem(t *testing.T) {
+	h := NewHelper(DefaultGraph())
+	s := h.FindSystem(2)
+	log.Printf("найдена система по ID: %+v", s)
+	if s == nil || s.Name != "Beta" {
+		t.Fatalf("ожидалась система Beta, получено %#v", s)
+	}
+	if res := h.FindSystem(999); res != nil {
+		t.Errorf("ожидалось nil, получено %+v", res)
+	}
+}
+
+// TestGetEndSystem проверяет извлечение конечной системы из названия Ansiblex.
+func TestGetEndSystem(t *testing.T) {
+	h := NewHelper(DefaultGraph())
+	ansiblex := "Alpha » Beta - jump bridge"
+	end := h.GetEndSystem(ansiblex)
+	log.Printf("конечная система: %+v", end)
+	if end == nil || end.Name != "Beta" {
+		t.Fatalf("ожидалась Beta, получено %#v", end)
+	}
+	if res := h.GetEndSystem("invalid format"); res != nil {
+		t.Errorf("ожидалось nil, получено %+v", res)
+	}
+	if res := h.GetEndSystem("Alpha » Unknown - test"); res != nil {
+		t.Errorf("ожидалось nil при отсутствии системы, получено %+v", res)
+	}
+}


### PR DESCRIPTION
## Summary
- add unit test for default graph structure
- add helper tests covering system search and Ansiblex parsing

## Testing
- `go test ./internal/graph`


------
https://chatgpt.com/codex/tasks/task_e_689a8958afd48325b15f4955f085b6a9