### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Go fmt
+        run: go fmt ./...
+
+      - name: Go test
+        run: go test ./...
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+          cache-dependency-path: frontend/yarn.lock
+
+      - name: Yarn install
+        working-directory: frontend
+        run: yarn install --immutable
+
+      - name: Yarn build
+        working-directory: frontend
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
+        run: yarn build


### PR DESCRIPTION
## Summary
- add CI workflow running go fmt, go test and yarn build with caching for Go modules and Yarn packages

## Testing
- `gofmt -w $(git ls-files '*.go')`
- `yarn --cwd frontend prettier` *(fails: script not found)*
- `go test ./...`
- `cd frontend && NODE_OPTIONS=--openssl-legacy-provider yarn build` *(fails: TypeScript error)*
- `act pull_request -n` *(fails: no Docker)*

------
https://chatgpt.com/codex/tasks/task_e_689a895d8d008325b0577470cc1c5029