### PR TITLE
Sort routes by temporary connections

### DIFF
--- a/internal/route/node.go
+++ b/internal/route/node.go
@@ -51,3 +51,14 @@ func (p path) numberOfAnsiblexes() int {
 	}
 	return count
 }
+
+// numberOfTemporary возвращает количество переходов через временные соединения.
+func (p path) numberOfTemporary() int {
+	count := 0
+	for _, w := range p.waypoints {
+		if w.ConnectionType != nil && *w.ConnectionType == TypeTemporary {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/route/route.go
+++ b/internal/route/route.go
@@ -67,7 +67,12 @@ func (r *Route) Find(from, to string) [][]Waypoint {
 		paths = append(paths, path{waypoints: wp})
 	}
 	sort.Slice(paths, func(i, j int) bool {
-		return paths[i].numberOfAnsiblexes() < paths[j].numberOfAnsiblexes()
+		ai := paths[i].numberOfAnsiblexes()
+		aj := paths[j].numberOfAnsiblexes()
+		if ai == aj {
+			return paths[i].numberOfTemporary() < paths[j].numberOfTemporary()
+		}
+		return ai < aj
 	})
 	var result [][]Waypoint
 	for _, p := range paths {

--- a/internal/route/route_test.go
+++ b/internal/route/route_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/tkhamez/eve-route-go/internal/db"
 )
 
+// TestRouteFindAnsiblex проверяет, что Ansiblex рассматривается как альтернативный маршрут.
 func TestRouteFindAnsiblex(t *testing.T) {
 	ansiblexes := []db.Ansiblex{
 		{ID: 1, Name: "Alpha » Gamma - Gate1", SolarSystemID: 1},
@@ -26,5 +27,28 @@ func TestRouteFindAnsiblex(t *testing.T) {
 	}
 	if paths[1][0].ConnectionType == nil || *paths[1][0].ConnectionType != TypeAnsiblex {
 		t.Fatalf("второй маршрут должен использовать Ansiblex")
+	}
+}
+
+// TestRouteSortTemporary проверяет сортировку по количеству временных соединений.
+func TestRouteSortTemporary(t *testing.T) {
+	temps := []db.TemporaryConnection{
+		{System1ID: 1, System2ID: 3},
+	}
+	removed := []ConnectedSystems{{System1: "Alpha", System2: "Gamma"}}
+	store := db.NewMemory(nil, temps, nil)
+	r, err := NewRoute(store, nil, removed)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	paths := r.Find("Alpha", "Gamma")
+	if len(paths) != 2 {
+		t.Fatalf("ожидались два маршрута, получено %d", len(paths))
+	}
+	if paths[0][0].ConnectionType == nil || *paths[0][0].ConnectionType != TypeStargate {
+		t.Fatalf("первый маршрут должен идти через Stargate")
+	}
+	if paths[1][0].ConnectionType == nil || *paths[1][0].ConnectionType != TypeTemporary {
+		t.Fatalf("второй маршрут должен использовать временное соединение")
 	}
 }


### PR DESCRIPTION
## Summary
- count temporary connections in paths
- prefer routes with fewer temporary links when Ansiblex count matches
- cover new sorting logic with tests and document exported tests

## Testing
- `go build -o eve-route` *(fails: go: updates to go.mod needed; to update it: go mod tidy)*
- `go test ./...` *(fails: go: updates to go.mod needed; to update it: go mod tidy)*

------
https://chatgpt.com/codex/tasks/task_e_689a8e033fc4832580a7ee51c91ecfae