### PR TITLE
Implement token store load and delete

### DIFF
--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"log"
 	"net/http"
+	"strconv"
 
 	"golang.org/x/oauth2"
 )
@@ -42,6 +43,30 @@ func (h *Handler) Callback(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "save failed", http.StatusInternalServerError)
 		return
 	}
+	if _, err := h.Store.Load(1); err != nil {
+		log.Println("token load failed:", err)
+	}
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte("ok"))
+}
+
+// Logout removes the token for the given user id.
+func (h *Handler) Logout(w http.ResponseWriter, r *http.Request) {
+	idStr := r.URL.Query().Get("id")
+	if idStr == "" {
+		http.Error(w, "missing id", http.StatusBadRequest)
+		return
+	}
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		http.Error(w, "invalid id", http.StatusBadRequest)
+		return
+	}
+	if err := h.Store.Delete(id); err != nil {
+		log.Println("token delete failed:", err)
+		http.Error(w, "delete failed", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("logged out"))
 }

--- a/internal/auth/storage_test.go
+++ b/internal/auth/storage_test.go
@@ -1,0 +1,64 @@
+package auth
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+func TestTokenStore_Load(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := NewTokenStore(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tok := &oauth2.Token{AccessToken: "a", RefreshToken: "r", Expiry: time.Unix(100, 0)}
+	if err := store.Save(tok); err != nil {
+		t.Fatal(err)
+	}
+	var id int
+	if err := db.QueryRow(`SELECT id FROM tokens`).Scan(&id); err != nil {
+		t.Fatal(err)
+	}
+	got, err := store.Load(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AccessToken != "a" || got.RefreshToken != "r" || !got.Expiry.Equal(time.Unix(100, 0)) {
+		t.Fatalf("unexpected token: %+v", got)
+	}
+}
+
+func TestTokenStore_Delete(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := NewTokenStore(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tok := &oauth2.Token{AccessToken: "a", RefreshToken: "r", Expiry: time.Now()}
+	if err := store.Save(tok); err != nil {
+		t.Fatal(err)
+	}
+	var id int
+	if err := db.QueryRow(`SELECT id FROM tokens`).Scan(&id); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Delete(id); err != nil {
+		t.Fatal(err)
+	}
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM tokens`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("expected 0 tokens, got %d", count)
+	}
+}


### PR DESCRIPTION
## Summary
- add Load and Delete operations to TokenStore backed by `tokens` table
- invoke token loading during callback and handle logout via token deletion
- cover TokenStore Load and Delete with tests

## Testing
- `go test ./...` *(fails: assignment mismatch in internal/api/route_test.go:14)*
- `go test ./internal/auth`


------
https://chatgpt.com/codex/tasks/task_e_689a8f709f348325973a34c99aee36b5