### PR TITLE
Implement database-backed store for Ansiblex and temporary connections

### DIFF
--- a/internal/api/ansiblex.go
+++ b/internal/api/ansiblex.go
@@ -1,195 +1,42 @@
 package api
 
 import (
-	"encoding/json"
-	"log"
 	"net/http"
-	"strconv"
-	"sync"
-	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/tkhamez/eve-route-go/internal/db"
 )
 
-// Ansiblex represents a permanent jump bridge.
-type Ansiblex struct {
-	ID   int    `json:"id"`
-	Name string `json:"name"`
-	From string `json:"from"`
-	To   string `json:"to"`
-}
-
-// TempConnection describes a temporary connection between systems.
-type TempConnection struct {
-	ID      int       `json:"id"`
-	From    string    `json:"from"`
-	To      string    `json:"to"`
-	Expires time.Time `json:"expires"`
-}
-
-// Store keeps Ansiblex and temporary connections in memory.
-type Store struct {
-	mu       sync.Mutex
-	nextID   int
-	ansiblex map[int]Ansiblex
-	temp     map[int]TempConnection
-}
-
-// NewStore creates a new in-memory store.
-func NewStore() *Store {
-	return &Store{ansiblex: make(map[int]Ansiblex), temp: make(map[int]TempConnection), nextID: 1}
+// Handler provides HTTP handlers for Ansiblex and temporary connections.
+type Handler struct {
+	store db.Store
+	token string
 }
 
 // RegisterAnsiblexRoutes registers API routes for Ansiblex and temporary connections.
-func RegisterAnsiblexRoutes(r *mux.Router, token string) *Store {
-	s := NewStore()
+func RegisterAnsiblexRoutes(r *mux.Router, token string, store db.Store) *Handler {
+	h := &Handler{store: store, token: token}
 	api := r.PathPrefix("/api").Subrouter()
 
-	api.HandleFunc("/ansiblex", s.listAnsiblex).Methods("GET")
-	api.Handle("/ansiblex", s.auth(token, http.HandlerFunc(s.createAnsiblex))).Methods("POST")
-	api.Handle("/ansiblex/{id}", s.auth(token, http.HandlerFunc(s.updateAnsiblex))).Methods("PUT")
-	api.Handle("/ansiblex/{id}", s.auth(token, http.HandlerFunc(s.deleteAnsiblex))).Methods("DELETE")
+	api.HandleFunc("/ansiblex", h.listAnsiblex).Methods("GET")
+	api.Handle("/ansiblex", h.auth(http.HandlerFunc(h.createAnsiblex))).Methods("POST")
+	api.Handle("/ansiblex/{id}", h.auth(http.HandlerFunc(h.updateAnsiblex))).Methods("PUT")
+	api.Handle("/ansiblex/{id}", h.auth(http.HandlerFunc(h.deleteAnsiblex))).Methods("DELETE")
 
-	api.HandleFunc("/temp", s.listTemp).Methods("GET")
-	api.Handle("/temp", s.auth(token, http.HandlerFunc(s.createTemp))).Methods("POST")
-	api.Handle("/temp/{id}", s.auth(token, http.HandlerFunc(s.updateTemp))).Methods("PUT")
-	api.Handle("/temp/{id}", s.auth(token, http.HandlerFunc(s.deleteTemp))).Methods("DELETE")
+	api.HandleFunc("/temp", h.listTemp).Methods("GET")
+	api.Handle("/temp", h.auth(http.HandlerFunc(h.createTemp))).Methods("POST")
+	api.Handle("/temp/{id}", h.auth(http.HandlerFunc(h.updateTemp))).Methods("PUT")
+	api.Handle("/temp/{id}", h.auth(http.HandlerFunc(h.deleteTemp))).Methods("DELETE")
 
-	return s
+	return h
 }
 
-func (s *Store) auth(token string, next http.Handler) http.Handler {
+func (h *Handler) auth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Authorization") != "Bearer "+token {
+		if r.Header.Get("Authorization") != "Bearer "+h.token {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
 		next.ServeHTTP(w, r)
 	})
-}
-
-func (s *Store) listAnsiblex(w http.ResponseWriter, _ *http.Request) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	var list []Ansiblex
-	for _, a := range s.ansiblex {
-		list = append(list, a)
-	}
-	_ = json.NewEncoder(w).Encode(list)
-}
-
-func (s *Store) createAnsiblex(w http.ResponseWriter, r *http.Request) {
-	var a Ansiblex
-	if err := json.NewDecoder(r.Body).Decode(&a); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-	s.mu.Lock()
-	a.ID = s.nextID
-	s.nextID++
-	s.ansiblex[a.ID] = a
-	s.mu.Unlock()
-	log.Printf("ansiblex created: %d", a.ID)
-	w.WriteHeader(http.StatusCreated)
-	_ = json.NewEncoder(w).Encode(a)
-}
-
-func (s *Store) updateAnsiblex(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.Atoi(mux.Vars(r)["id"])
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-	var a Ansiblex
-	if err := json.NewDecoder(r.Body).Decode(&a); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-	s.mu.Lock()
-	if _, ok := s.ansiblex[id]; !ok {
-		s.mu.Unlock()
-		http.NotFound(w, r)
-		return
-	}
-	a.ID = id
-	s.ansiblex[id] = a
-	s.mu.Unlock()
-	log.Printf("ansiblex updated: %d", id)
-	_ = json.NewEncoder(w).Encode(a)
-}
-
-func (s *Store) deleteAnsiblex(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.Atoi(mux.Vars(r)["id"])
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-	s.mu.Lock()
-	delete(s.ansiblex, id)
-	s.mu.Unlock()
-	log.Printf("ansiblex deleted: %d", id)
-	w.WriteHeader(http.StatusNoContent)
-}
-
-func (s *Store) listTemp(w http.ResponseWriter, _ *http.Request) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	var list []TempConnection
-	for _, t := range s.temp {
-		list = append(list, t)
-	}
-	_ = json.NewEncoder(w).Encode(list)
-}
-
-func (s *Store) createTemp(w http.ResponseWriter, r *http.Request) {
-	var t TempConnection
-	if err := json.NewDecoder(r.Body).Decode(&t); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-	s.mu.Lock()
-	t.ID = s.nextID
-	s.nextID++
-	s.temp[t.ID] = t
-	s.mu.Unlock()
-	log.Printf("temp connection created: %d", t.ID)
-	w.WriteHeader(http.StatusCreated)
-	_ = json.NewEncoder(w).Encode(t)
-}
-
-func (s *Store) updateTemp(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.Atoi(mux.Vars(r)["id"])
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-	var t TempConnection
-	if err := json.NewDecoder(r.Body).Decode(&t); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-	s.mu.Lock()
-	if _, ok := s.temp[id]; !ok {
-		s.mu.Unlock()
-		http.NotFound(w, r)
-		return
-	}
-	t.ID = id
-	s.temp[id] = t
-	s.mu.Unlock()
-	log.Printf("temp connection updated: %d", id)
-	_ = json.NewEncoder(w).Encode(t)
-}
-
-func (s *Store) deleteTemp(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.Atoi(mux.Vars(r)["id"])
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-	s.mu.Lock()
-	delete(s.temp, id)
-	s.mu.Unlock()
-	log.Printf("temp connection deleted: %d", id)
-	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/api/ansiblex_handlers.go
+++ b/internal/api/ansiblex_handlers.go
@@ -1,0 +1,131 @@
+package api
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+	"github.com/tkhamez/eve-route-go/internal/db"
+)
+
+func (h *Handler) listAnsiblex(w http.ResponseWriter, r *http.Request) {
+	list, err := h.store.Ansiblexes(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(list)
+}
+
+func (h *Handler) createAnsiblex(w http.ResponseWriter, r *http.Request) {
+	var a db.Ansiblex
+	if err := json.NewDecoder(r.Body).Decode(&a); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	id, err := h.store.CreateAnsiblex(r.Context(), a)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	a.ID = id
+	log.Printf("ansiblex created: %d", id)
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(a)
+}
+
+func (h *Handler) updateAnsiblex(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(mux.Vars(r)["id"], 10, 64)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	var a db.Ansiblex
+	if err := json.NewDecoder(r.Body).Decode(&a); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	a.ID = id
+	if err := h.store.UpdateAnsiblex(r.Context(), a); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	log.Printf("ansiblex updated: %d", id)
+	_ = json.NewEncoder(w).Encode(a)
+}
+
+func (h *Handler) deleteAnsiblex(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(mux.Vars(r)["id"], 10, 64)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := h.store.DeleteAnsiblex(r.Context(), id); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	log.Printf("ansiblex deleted: %d", id)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) listTemp(w http.ResponseWriter, r *http.Request) {
+	list, err := h.store.TemporaryConnections(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(list)
+}
+
+func (h *Handler) createTemp(w http.ResponseWriter, r *http.Request) {
+	var c db.TemporaryConnection
+	if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	id, err := h.store.CreateTemporaryConnection(r.Context(), c)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	c.ID = id
+	log.Printf("temp connection created: %d", id)
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(c)
+}
+
+func (h *Handler) updateTemp(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(mux.Vars(r)["id"], 10, 64)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	var c db.TemporaryConnection
+	if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	c.ID = id
+	if err := h.store.UpdateTemporaryConnection(r.Context(), c); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	log.Printf("temp connection updated: %d", id)
+	_ = json.NewEncoder(w).Encode(c)
+}
+
+func (h *Handler) deleteTemp(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(mux.Vars(r)["id"], 10, 64)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := h.store.DeleteTemporaryConnection(r.Context(), id); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	log.Printf("temp connection deleted: %d", id)
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/api/ansiblex_test.go
+++ b/internal/api/ansiblex_test.go
@@ -3,18 +3,21 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/gorilla/mux"
+	"github.com/tkhamez/eve-route-go/internal/db"
 )
 
-func TestAnsiblexAuth(t *testing.T) {
+func TestAnsiblexCRUD(t *testing.T) {
 	r := mux.NewRouter()
-	RegisterAnsiblexRoutes(r, "token")
+	store := db.NewMemory(nil, nil, nil)
+	RegisterAnsiblexRoutes(r, "token", store)
 
-	body := bytes.NewBufferString(`{"name":"A","from":"X","to":"Y"}`)
+	body := bytes.NewBufferString(`{"name":"A","solarSystemID":1}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/ansiblex", body)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -22,13 +25,24 @@ func TestAnsiblexAuth(t *testing.T) {
 		t.Fatalf("expected 401, got %d", w.Code)
 	}
 
-	body = bytes.NewBufferString(`{"name":"A","from":"X","to":"Y"}`)
+	body = bytes.NewBufferString(`{"name":"A","solarSystemID":1}`)
 	req = httptest.NewRequest(http.MethodPost, "/api/ansiblex", body)
 	req.Header.Set("Authorization", "Bearer token")
 	w = httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	if w.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d", w.Code)
+	}
+	var created db.Ansiblex
+	_ = json.NewDecoder(w.Body).Decode(&created)
+
+	body = bytes.NewBufferString(`{"name":"B","solarSystemID":1}`)
+	req = httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/ansiblex/%d", created.ID), body)
+	req.Header.Set("Authorization", "Bearer token")
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
 	}
 
 	req = httptest.NewRequest(http.MethodGet, "/api/ansiblex", nil)
@@ -37,21 +51,79 @@ func TestAnsiblexAuth(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
-	var list []Ansiblex
-	if err := json.NewDecoder(w.Body).Decode(&list); err != nil || len(list) != 1 {
-		t.Fatalf("expected one element, got %v %v", len(list), err)
+	var list []db.Ansiblex
+	_ = json.NewDecoder(w.Body).Decode(&list)
+	if len(list) != 1 || list[0].Name != "B" {
+		t.Fatalf("unexpected list %v", list)
+	}
+
+	req = httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/ansiblex/%d", created.ID), nil)
+	req.Header.Set("Authorization", "Bearer token")
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/ansiblex", nil)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	_ = json.NewDecoder(w.Body).Decode(&list)
+	if len(list) != 0 {
+		t.Fatalf("expected empty list, got %v", list)
 	}
 }
 
-func TestTempAuth(t *testing.T) {
+func TestTempCRUD(t *testing.T) {
 	r := mux.NewRouter()
-	RegisterAnsiblexRoutes(r, "token")
+	store := db.NewMemory(nil, nil, nil)
+	RegisterAnsiblexRoutes(r, "token", store)
 
-	body := bytes.NewBufferString(`{"from":"X","to":"Y"}`)
+	body := bytes.NewBufferString(`{"system1ID":1,"system2ID":2}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/temp", body)
+	req.Header.Set("Authorization", "Bearer token")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
-	if w.Code != http.StatusUnauthorized {
-		t.Fatalf("expected 401, got %d", w.Code)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", w.Code)
+	}
+	var created db.TemporaryConnection
+	_ = json.NewDecoder(w.Body).Decode(&created)
+
+	body = bytes.NewBufferString(`{"system1ID":3,"system2ID":4}`)
+	req = httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/temp/%d", created.ID), body)
+	req.Header.Set("Authorization", "Bearer token")
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/temp", nil)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var list []db.TemporaryConnection
+	_ = json.NewDecoder(w.Body).Decode(&list)
+	if len(list) != 1 || list[0].System1ID != 3 {
+		t.Fatalf("unexpected list %v", list)
+	}
+
+	req = httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/temp/%d", created.ID), nil)
+	req.Header.Set("Authorization", "Bearer token")
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/temp", nil)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	_ = json.NewDecoder(w.Body).Decode(&list)
+	if len(list) != 0 {
+		t.Fatalf("expected empty list, got %v", list)
 	}
 }

--- a/internal/api/route_test.go
+++ b/internal/api/route_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
+	"github.com/tkhamez/eve-route-go/internal/db"
 	routepkg "github.com/tkhamez/eve-route-go/internal/route"
 )
 
 func TestNewRouteHandler(t *testing.T) {
-	planner := routepkg.NewRoute(nil, nil, nil, nil)
+	planner, _ := routepkg.NewRoute(db.NewMemory(nil, nil, nil), nil, nil)
 	router := mux.NewRouter()
 	router.HandleFunc("/api/route/{from}/{to}", NewRouteHandler(planner)).Methods("GET")
 
@@ -42,7 +43,7 @@ func TestNewRouteHandler(t *testing.T) {
 }
 
 func TestNewRouteHandlerNotFound(t *testing.T) {
-	planner := routepkg.NewRoute(nil, nil, nil, nil)
+	planner, _ := routepkg.NewRoute(db.NewMemory(nil, nil, nil), nil, nil)
 	router := mux.NewRouter()
 	router.HandleFunc("/api/route/{from}/{to}", NewRouteHandler(planner)).Methods("GET")
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -4,16 +4,17 @@ import "context"
 
 // Ansiblex represents Ansiblex gate data.
 type Ansiblex struct {
-	ID            int64
-	Name          string
-	SolarSystemID int
-	RegionID      *int
+	ID            int64  `json:"id"`
+	Name          string `json:"name"`
+	SolarSystemID int    `json:"solarSystemID"`
+	RegionID      *int   `json:"regionID,omitempty"`
 }
 
 // TemporaryConnection represents temporary connection between two systems.
 type TemporaryConnection struct {
-	System1ID int
-	System2ID int
+	ID        int64 `json:"id"`
+	System1ID int   `json:"system1ID"`
+	System2ID int   `json:"system2ID"`
 }
 
 // System represents a solar system for capital routes.
@@ -30,4 +31,12 @@ type Store interface {
 	Ansiblexes(ctx context.Context) ([]Ansiblex, error)
 	TemporaryConnections(ctx context.Context) ([]TemporaryConnection, error)
 	Systems(ctx context.Context) (map[int]System, error)
+
+	CreateAnsiblex(ctx context.Context, a Ansiblex) (int64, error)
+	UpdateAnsiblex(ctx context.Context, a Ansiblex) error
+	DeleteAnsiblex(ctx context.Context, id int64) error
+
+	CreateTemporaryConnection(ctx context.Context, c TemporaryConnection) (int64, error)
+	UpdateTemporaryConnection(ctx context.Context, c TemporaryConnection) error
+	DeleteTemporaryConnection(ctx context.Context, id int64) error
 }

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -1,12 +1,17 @@
 package db
 
-import "context"
+import (
+	"context"
+	"errors"
+)
 
 // Memory provides an in-memory implementation of Store for tests.
 type Memory struct {
 	ansiblexes      []Ansiblex
 	tempConnections []TemporaryConnection
 	systems         map[int]System
+	nextAnsiblexID  int64
+	nextTempID      int64
 }
 
 // NewMemory creates a new in-memory store instance.
@@ -20,7 +25,18 @@ func NewMemory(ans []Ansiblex, temps []TemporaryConnection, systems map[int]Syst
 	if systems == nil {
 		systems = map[int]System{}
 	}
-	return &Memory{ansiblexes: ans, tempConnections: temps, systems: systems}
+	m := &Memory{ansiblexes: ans, tempConnections: temps, systems: systems}
+	for _, a := range ans {
+		if a.ID >= m.nextAnsiblexID {
+			m.nextAnsiblexID = a.ID + 1
+		}
+	}
+	for _, t := range temps {
+		if t.ID >= m.nextTempID {
+			m.nextTempID = t.ID + 1
+		}
+	}
+	return m
 }
 
 // Ansiblexes returns all Ansiblex gates.
@@ -36,4 +52,64 @@ func (m *Memory) TemporaryConnections(ctx context.Context) ([]TemporaryConnectio
 // Systems returns capital systems information.
 func (m *Memory) Systems(ctx context.Context) (map[int]System, error) {
 	return m.systems, nil
+}
+
+// CreateAnsiblex inserts a new Ansiblex gate.
+func (m *Memory) CreateAnsiblex(ctx context.Context, a Ansiblex) (int64, error) {
+	a.ID = m.nextAnsiblexID
+	m.nextAnsiblexID++
+	m.ansiblexes = append(m.ansiblexes, a)
+	return a.ID, nil
+}
+
+// UpdateAnsiblex updates an existing Ansiblex gate.
+func (m *Memory) UpdateAnsiblex(ctx context.Context, a Ansiblex) error {
+	for i := range m.ansiblexes {
+		if m.ansiblexes[i].ID == a.ID {
+			m.ansiblexes[i] = a
+			return nil
+		}
+	}
+	return errors.New("ansiblex not found")
+}
+
+// DeleteAnsiblex removes an Ansiblex gate.
+func (m *Memory) DeleteAnsiblex(ctx context.Context, id int64) error {
+	for i := range m.ansiblexes {
+		if m.ansiblexes[i].ID == id {
+			m.ansiblexes = append(m.ansiblexes[:i], m.ansiblexes[i+1:]...)
+			return nil
+		}
+	}
+	return errors.New("ansiblex not found")
+}
+
+// CreateTemporaryConnection inserts a new temporary connection.
+func (m *Memory) CreateTemporaryConnection(ctx context.Context, c TemporaryConnection) (int64, error) {
+	c.ID = m.nextTempID
+	m.nextTempID++
+	m.tempConnections = append(m.tempConnections, c)
+	return c.ID, nil
+}
+
+// UpdateTemporaryConnection updates an existing temporary connection.
+func (m *Memory) UpdateTemporaryConnection(ctx context.Context, c TemporaryConnection) error {
+	for i := range m.tempConnections {
+		if m.tempConnections[i].ID == c.ID {
+			m.tempConnections[i] = c
+			return nil
+		}
+	}
+	return errors.New("temporary connection not found")
+}
+
+// DeleteTemporaryConnection removes a temporary connection.
+func (m *Memory) DeleteTemporaryConnection(ctx context.Context, id int64) error {
+	for i := range m.tempConnections {
+		if m.tempConnections[i].ID == id {
+			m.tempConnections = append(m.tempConnections[:i], m.tempConnections[i+1:]...)
+			return nil
+		}
+	}
+	return errors.New("temporary connection not found")
 }

--- a/internal/db/mongo.go
+++ b/internal/db/mongo.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"log"
+	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -78,6 +79,48 @@ func (m *Mongo) Systems(ctx context.Context) (map[int]System, error) {
 		return nil, err
 	}
 	return systems, nil
+}
+
+// CreateAnsiblex inserts a new Ansiblex gate.
+func (m *Mongo) CreateAnsiblex(ctx context.Context, a Ansiblex) (int64, error) {
+	if a.ID == 0 {
+		a.ID = time.Now().UnixNano()
+	}
+	_, err := m.collection("ansiblex").InsertOne(ctx, a)
+	return a.ID, err
+}
+
+// UpdateAnsiblex updates an existing Ansiblex gate.
+func (m *Mongo) UpdateAnsiblex(ctx context.Context, a Ansiblex) error {
+	_, err := m.collection("ansiblex").UpdateOne(ctx, bson.M{"id": a.ID}, bson.M{"$set": a})
+	return err
+}
+
+// DeleteAnsiblex removes an Ansiblex gate.
+func (m *Mongo) DeleteAnsiblex(ctx context.Context, id int64) error {
+	_, err := m.collection("ansiblex").DeleteOne(ctx, bson.M{"id": id})
+	return err
+}
+
+// CreateTemporaryConnection inserts a new temporary connection.
+func (m *Mongo) CreateTemporaryConnection(ctx context.Context, c TemporaryConnection) (int64, error) {
+	if c.ID == 0 {
+		c.ID = time.Now().UnixNano()
+	}
+	_, err := m.collection("temporary_connections").InsertOne(ctx, c)
+	return c.ID, err
+}
+
+// UpdateTemporaryConnection updates an existing temporary connection.
+func (m *Mongo) UpdateTemporaryConnection(ctx context.Context, c TemporaryConnection) error {
+	_, err := m.collection("temporary_connections").UpdateOne(ctx, bson.M{"id": c.ID}, bson.M{"$set": c})
+	return err
+}
+
+// DeleteTemporaryConnection removes a temporary connection.
+func (m *Mongo) DeleteTemporaryConnection(ctx context.Context, id int64) error {
+	_, err := m.collection("temporary_connections").DeleteOne(ctx, bson.M{"id": id})
+	return err
 }
 
 // EnsureMongoConnection pings the database to check connection.

--- a/internal/db/postgres.go
+++ b/internal/db/postgres.go
@@ -38,7 +38,7 @@ func (p *Postgres) Ansiblexes(ctx context.Context) ([]Ansiblex, error) {
 
 // TemporaryConnections loads temporary connections from PostgreSQL.
 func (p *Postgres) TemporaryConnections(ctx context.Context) ([]TemporaryConnection, error) {
-	rows, err := p.db.QueryContext(ctx, "SELECT system1_id, system2_id FROM temporary_connections")
+	rows, err := p.db.QueryContext(ctx, "SELECT id, system1_id, system2_id FROM temporary_connections")
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func (p *Postgres) TemporaryConnections(ctx context.Context) ([]TemporaryConnect
 	var res []TemporaryConnection
 	for rows.Next() {
 		var c TemporaryConnection
-		if err := rows.Scan(&c.System1ID, &c.System2ID); err != nil {
+		if err := rows.Scan(&c.ID, &c.System1ID, &c.System2ID); err != nil {
 			return nil, err
 		}
 		res = append(res, c)
@@ -70,6 +70,44 @@ func (p *Postgres) Systems(ctx context.Context) (map[int]System, error) {
 		systems[s.ID] = s
 	}
 	return systems, rows.Err()
+}
+
+// CreateAnsiblex inserts a new Ansiblex gate.
+func (p *Postgres) CreateAnsiblex(ctx context.Context, a Ansiblex) (int64, error) {
+	var id int64
+	err := p.db.QueryRowContext(ctx, "INSERT INTO ansiblex (name, solar_system_id, region_id) VALUES ($1,$2,$3) RETURNING id", a.Name, a.SolarSystemID, a.RegionID).Scan(&id)
+	return id, err
+}
+
+// UpdateAnsiblex updates an existing Ansiblex gate.
+func (p *Postgres) UpdateAnsiblex(ctx context.Context, a Ansiblex) error {
+	_, err := p.db.ExecContext(ctx, "UPDATE ansiblex SET name=$1, solar_system_id=$2, region_id=$3 WHERE id=$4", a.Name, a.SolarSystemID, a.RegionID, a.ID)
+	return err
+}
+
+// DeleteAnsiblex removes an Ansiblex gate.
+func (p *Postgres) DeleteAnsiblex(ctx context.Context, id int64) error {
+	_, err := p.db.ExecContext(ctx, "DELETE FROM ansiblex WHERE id=$1", id)
+	return err
+}
+
+// CreateTemporaryConnection inserts a new temporary connection.
+func (p *Postgres) CreateTemporaryConnection(ctx context.Context, c TemporaryConnection) (int64, error) {
+	var id int64
+	err := p.db.QueryRowContext(ctx, "INSERT INTO temporary_connections (system1_id, system2_id) VALUES ($1,$2) RETURNING id", c.System1ID, c.System2ID).Scan(&id)
+	return id, err
+}
+
+// UpdateTemporaryConnection updates an existing temporary connection.
+func (p *Postgres) UpdateTemporaryConnection(ctx context.Context, c TemporaryConnection) error {
+	_, err := p.db.ExecContext(ctx, "UPDATE temporary_connections SET system1_id=$1, system2_id=$2 WHERE id=$3", c.System1ID, c.System2ID, c.ID)
+	return err
+}
+
+// DeleteTemporaryConnection removes a temporary connection.
+func (p *Postgres) DeleteTemporaryConnection(ctx context.Context, id int64) error {
+	_, err := p.db.ExecContext(ctx, "DELETE FROM temporary_connections WHERE id=$1", id)
+	return err
 }
 
 // EnsurePostgresConnection pings the database to check connection.

--- a/internal/route/route_test.go
+++ b/internal/route/route_test.go
@@ -35,9 +35,8 @@ func TestRouteSortTemporary(t *testing.T) {
 	temps := []db.TemporaryConnection{
 		{System1ID: 1, System2ID: 3},
 	}
-	removed := []ConnectedSystems{{System1: "Alpha", System2: "Gamma"}}
 	store := db.NewMemory(nil, temps, nil)
-	r, err := NewRoute(store, nil, removed)
+	r, err := NewRoute(store, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- add CRUD operations to db.Store with JSON models
- persist Ansiblex and temporary connections via Postgres/Mongo/Memory implementations
- rework Ansiblex API routes to use database store and cover with tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689a8f73c72c8325b4893b004f62b432